### PR TITLE
[Github CI] Reenable MSVC compiler testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,19 +12,27 @@ on:
 jobs:
 
   # FIXME: We're having a linker error wrt. Catch2 on Windows with MSVC
-  # windows-msvc:
-  #   name: "Windows - MSVC"
-  #   runs-on: windows-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Install dependencies
-  #       run: choco install ninja
-  #     - name: configure
-  #       run: cmake --preset windows-cl-release
-  #     - name: build
-  #       run: cmake --build --preset windows-cl-release
-  #     - name: test
-  #       run: ctest --preset windows-cl-release -VV
+  windows-msvc:
+    name: "Windows - MSVC"
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: choco install ninja
+      - name: "vcpkg: Install dependencies"
+        uses: lukka/run-vcpkg@v11.1
+        id: runvcpkg
+        with:
+          vcpkgDirectory: ${{ runner.workspace }}/vcpkg
+          vcpkgGitCommitId: 80403036a665cb8fcc1a1b3e17593d20b03b2489
+      - name: configure
+        run: cmake --preset windows-cl-release -D REFLECTION_TESTING=ON
+        env:
+          VCPKG_ROOT: "${{ runner.workspace }}/vcpkg"
+      - name: build
+        run: cmake --build --preset windows-cl-release
+      - name: test
+        run: ctest --preset windows-cl-release -VV
 
   ubuntu24-clang:
     name: "Ubuntu Linux - Clang ${{ matrix.clang_version }}"
@@ -43,7 +51,7 @@ jobs:
       - name: Install ninja and catch2
         run: sudo apt-get install ninja-build catch2
       - name: configure
-        run: cmake --preset linux-clang-release  -D REFLECTION_TESTING=ON
+        run: cmake --preset linux-clang-release -D REFLECTION_TESTING=ON
       - name: build
         run: cmake --build --preset linux-clang-release
       - name: test

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -31,6 +31,7 @@
             "inherits": ["windows-common"],
             "generator": "Visual Studio 17 2022",
             "cacheVariables": {
+                "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
                 "CMAKE_CXX_COMPILER": "cl"
             }
         },

--- a/cmake/ThirdParties.cmake
+++ b/cmake/ThirdParties.cmake
@@ -19,36 +19,43 @@ message(STATUS "base dir: ${FETCHCONTENT_BASE_DIR}")
 message(STATUS "dnld dir: ${3rdparty_DOWNLOAD_DIR}")
 
 macro(ThirdPartiesAdd_Catch2)
-    set(3rdparty_Catch2_VERSION "3.4.0" CACHE STRING "Embedded catch2 version")
-    set(3rdparty_Catch2_CHECKSUM "SHA256=122928b814b75717316c71af69bd2b43387643ba076a6ec16e7882bfb2dfacbb" CACHE STRING "Embedded catch2 checksum")
-    set(3rdparty_Catch2_URL "https://github.com/catchorg/Catch2/archive/refs/tags/v${3rdparty_Catch2_VERSION}.tar.gz")
-    set(CATCH_BUILD_EXAMPLES OFF CACHE INTERNAL "")
-    set(CATCH_BUILD_EXTRA_TESTS OFF CACHE INTERNAL "")
-    set(CATCH_BUILD_TESTING OFF CACHE INTERNAL "")
-    set(CATCH_ENABLE_WERROR OFF CACHE INTERNAL "")
-    set(CATCH_INSTALL_DOCS OFF CACHE INTERNAL "")
-    set(CATCH_INSTALL_HELPERS OFF CACHE INTERNAL "")
-    if(THIRDPARTIES_HAS_FETCHCONTENT)
-        FetchContent_Declare(
-            Catch2
-            URL "${3rdparty_Catch2_URL}"
-            URL_HASH "${3rdparty_Catch2_CHECKSUM}"
-            DOWNLOAD_DIR "${3rdparty_DOWNLOAD_DIR}"
-            DOWNLOAD_NAME "catch2-${3rdparty_Catch2_VERSION}.tar.gz"
-            EXCLUDE_FROM_ALL
-            DOWNLOAD_EXTRACT_TIMESTAMP 1
-        )
-        FetchContent_MakeAvailable(Catch2)
+    #find_package(Catch2 QUIET)
+    find_package(Catch2)
+    if (Catch2_FOUND)
+        message(STATUS "Catch2 found: ${Catch2_DIR}")
     else()
-        download_project(
-            PROJ Catch2
-            URL "${3rdparty_Catch2_URL}"
-            URL_HASH "${3rdparty_Catch2_CHECKSUM}"
-            PREFIX "${FETCHCONTENT_BASE_DIR}/Catch2-${3rdparty_Catch2_VERSION}"
-            DOWNLOAD_DIR "${3rdparty_DOWNLOAD_DIR}"
-            DOWNLOAD_NAME "catch2-${3rdparty_Catch2_VERSION}.tar.gz"
-            EXCLUDE_FROM_ALL
-            DOWNLOAD_EXTRACT_TIMESTAMP 1
-        )
+        message(STATUS "Catch2 not found as system package, adding it as a thirdparty")
+        set(3rdparty_Catch2_VERSION "3.4.0" CACHE STRING "Embedded catch2 version")
+        set(3rdparty_Catch2_CHECKSUM "SHA256=122928b814b75717316c71af69bd2b43387643ba076a6ec16e7882bfb2dfacbb" CACHE STRING "Embedded catch2 checksum")
+        set(3rdparty_Catch2_URL "https://github.com/catchorg/Catch2/archive/refs/tags/v${3rdparty_Catch2_VERSION}.tar.gz")
+        set(CATCH_BUILD_EXAMPLES OFF CACHE INTERNAL "")
+        set(CATCH_BUILD_EXTRA_TESTS OFF CACHE INTERNAL "")
+        set(CATCH_BUILD_TESTING OFF CACHE INTERNAL "")
+        set(CATCH_ENABLE_WERROR OFF CACHE INTERNAL "")
+        set(CATCH_INSTALL_DOCS OFF CACHE INTERNAL "")
+        set(CATCH_INSTALL_HELPERS OFF CACHE INTERNAL "")
+        if(THIRDPARTIES_HAS_FETCHCONTENT)
+            FetchContent_Declare(
+                Catch2
+                URL "${3rdparty_Catch2_URL}"
+                URL_HASH "${3rdparty_Catch2_CHECKSUM}"
+                DOWNLOAD_DIR "${3rdparty_DOWNLOAD_DIR}"
+                DOWNLOAD_NAME "catch2-${3rdparty_Catch2_VERSION}.tar.gz"
+                EXCLUDE_FROM_ALL
+                DOWNLOAD_EXTRACT_TIMESTAMP 1
+            )
+            FetchContent_MakeAvailable(Catch2)
+        else()
+            download_project(
+                PROJ Catch2
+                URL "${3rdparty_Catch2_URL}"
+                URL_HASH "${3rdparty_Catch2_CHECKSUM}"
+                PREFIX "${FETCHCONTENT_BASE_DIR}/Catch2-${3rdparty_Catch2_VERSION}"
+                DOWNLOAD_DIR "${3rdparty_DOWNLOAD_DIR}"
+                DOWNLOAD_NAME "catch2-${3rdparty_Catch2_VERSION}.tar.gz"
+                EXCLUDE_FROM_ALL
+                DOWNLOAD_EXTRACT_TIMESTAMP 1
+            )
+        endif()
     endif()
 endmacro()

--- a/include/reflection-cpp/reflection.hpp
+++ b/include/reflection-cpp/reflection.hpp
@@ -672,7 +672,8 @@ consteval auto GetName()
 #if defined(_MSC_VER) && !defined(__clang__)
     std::string_view str = REFLECTION_PRETTY_FUNCTION;
     str = str.substr(str.rfind("::") + 2);
-    return str.substr(0, str.find('>'));
+    str = str.substr(0, str.find('>'));
+    return str.substr(str.find('<')+1);
 #else
     constexpr auto MarkerStart = std::string_view { "E = " };
     std::string_view str = REFLECTION_PRETTY_FUNCTION;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+    "builtin-baseline": "80403036a665cb8fcc1a1b3e17593d20b03b2489",
+    "dependencies": [
+        { "name": "catch2", "version>=": "3.4.0" }
+    ]
+}


### PR DESCRIPTION
@Yaraslaut the current way of finding Catch2 on windows produced a linker error. This is why I disabled windows CI back then. It should always favor system packages if present anyways, so I've tweaked that bit a bit.

But now I realized, that the tests where breaking on MSVC. I hope to find some time to check on why soon, too.