### PR TITLE
Add MemberClassType<P> and MemberIndexOf<P> to get the class type and member-index of P.

### DIFF
--- a/test-reflection-cpp.cpp
+++ b/test-reflection-cpp.cpp
@@ -35,6 +35,13 @@ struct SingleValueRecord
     int value;
 };
 
+TEST_CASE("MemberIndex", "[reflection]")
+{
+    static_assert(Reflection::MemberIndexOf<&Person::name> == 0);
+    static_assert(Reflection::MemberIndexOf<&Person::email> == 1);
+    static_assert(Reflection::MemberIndexOf<&Person::age> == 2);
+}
+
 TEST_CASE("TypeNameOf", "[reflection]")
 {
     CHECK(Reflection::TypeNameOf<int> == "int");


### PR DESCRIPTION
The smallest lines of code changes usually take the longest to code ;)

p.s.: I'm going to create a PR in Lightweight tonight to adapt it, and to provide sparse field querying.