### PR TITLE
Add CallOnMembersWithoutName function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(reflection-cpp VERSION 0.3.0 LANGUAGES CXX)
+project(reflection-cpp VERSION 0.3.1 LANGUAGES CXX)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/include/reflection-cpp/reflection.hpp
+++ b/include/reflection-cpp/reflection.hpp
@@ -1264,10 +1264,16 @@ constexpr void EnumerateMembers(Callable&& callable)
 }
 
 template <typename Object, typename Callable>
-    requires std::same_as<void, std::invoke_result_t<Callable, std::string, MemberTypeOf<0, Object>>>
+    requires std::is_invocable_v<Callable, std::string, MemberTypeOf<0, Object>>
 void CallOnMembers(Object& object, Callable&& callable)
 {
     EnumerateMembers(object, [&]<size_t I, typename T>(T&& value) { callable(MemberNameOf<I, Object>, value); });
+}
+
+template <typename Object, typename Callable>
+void CallOnMembersWithoutName(Object& object, Callable&& callable)
+{
+  EnumerateMembers(object, [&]<size_t I, typename T>(T&& value) { callable.template operator()<I, T>(value); });
 }
 
 /// Folds over the members of a type without an object of it.

--- a/test-reflection-cpp.cpp
+++ b/test-reflection-cpp.cpp
@@ -78,6 +78,7 @@ TEST_CASE("single value record", "[reflection]")
         CHECK(name == "value");
         CHECK(value == 42);
     });
+
 }
 
 TEST_CASE("core", "[reflection]")
@@ -181,6 +182,12 @@ TEST_CASE("CallOnMembers", "[reflection]")
         result += " ";
     });
     CHECK(result == R"(name=John Doe email=john@doe.com age=42 )");
+
+    std::string resultAnother;
+    Reflection::CallOnMembersWithoutName(ps, [&resultAnother]<size_t I, typename FieldType>(FieldType const& value) {
+        resultAnother += std::format("{}", value);
+    });
+    CHECK(resultAnother == R"(John Doejohn@doe.com42)");
 }
 
 TEST_CASE("FoldMembers.type", "[reflection]")


### PR DESCRIPTION
Add  CallOnMembersWithoutName that allows you to get template argument for the index of the member variable in the structure 